### PR TITLE
unit7 typo and link fixes

### DIFF
--- a/unit7/Unit7-factorial.ipynb
+++ b/unit7/Unit7-factorial.ipynb
@@ -44,7 +44,7 @@
     " & \\sum (\\alpha \\beta)_{ij} = 0 && \\text{STZ constraint for } \\alpha \\beta \\text{ interaction}\\\\\n",
     "\\end{align*}$$\n",
     "\n",
-    "$\\sigma_0^2$, $\\sigma_i^2$, anf $\\sigma_j^2$ are representing prior variances of the grand mean and treatment groups for each factor. Non-informative variances might be something like $\\sigma_0^2 = \\sigma_i^2 = \\sigma_j^2 = 1000$.\n",
+    "$\\sigma_0^2$, $\\sigma_i^2$, and $\\sigma_j^2$ are representing prior variances of the grand mean and treatment groups for each factor. Non-informative variances might be something like $\\sigma_0^2 = \\sigma_i^2 = \\sigma_j^2 = 1000$.\n",
     "\n",
     "## Authors\n",
     "\n",

--- a/unit7/Unit7-hiddenmixtures.ipynb
+++ b/unit7/Unit7-hiddenmixtures.ipynb
@@ -43,7 +43,7 @@
     "\\end{align*}\n",
     "$$\n",
     "\n",
-    "We can apply [The definition of Mixture Distribution from Wikipedia](https://en.wikipedia.org/wiki/Mixture_distribution/#Uncountable_mixtures) (*See \"Uncountable mixtures\" heading*) to derive the resulting density function:\n",
+    "We can apply [The definition of Mixture Distribution from Wikipedia](https://en.wikipedia.org/wiki/Mixture_distribution#Uncountable_mixtures) (*See \"Uncountable mixtures\" heading*) to derive the resulting density function:\n",
     "\n",
     "\n",
     "\\begin{align*}\n",

--- a/unit7/Unit7-multilevel.ipynb
+++ b/unit7/Unit7-multilevel.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "Advantages of multilevel models can be to learn about treatment effects that vary by group. This type of model allows us to \"borrow strength\" from all of the data to make inferences about smaller sample-size groups.\n",
     "\n",
-    "We also may be able to achieve better fitting models, by accounting for the uncertainty at different levels. Another example is with $Poission(\\lambda)$ regression:\n",
+    "We also may be able to achieve better fitting models, by accounting for the uncertainty at different levels. Another example is with $Poisson(\\lambda)$ regression:\n",
     "\n",
     "$$ \\begin{align*}\n",
     "y_{i} & \\sim Poisson(\\lambda_i)\\\\\n",

--- a/unit7/Unit7-priors.ipynb
+++ b/unit7/Unit7-priors.ipynb
@@ -27,7 +27,7 @@
     "r & \\sim \\text{Beta}(2,2) \\\\\n",
     "\\end{align*} $$\n",
     "\n",
-    "It is expected that $p$ should be around 0.5, so the prior on $p$ is set with $\\alpha = \\beta$, since the mean of a Beta distribution is $k / (k+k) = 0.5$. Lower values of $k$ result in a wider Beta distribution, while higher values of $k$ result in a tigher distribution.\n",
+    "It is expected that $p$ should be around 0.5, so the prior on $p$ is set with $\\alpha = \\beta$, since the mean of a Beta distribution is $k / (k+k) = 0.5$. Lower values of $k$ result in a wider Beta distribution, while higher values of $k$ result in a tighter distribution.\n",
     "\n",
     "The idea is that structural information is contained in the $p | k \\sim \\text{Beta} (k,k)$, while priors on $k$ and $r$ contain subjective information, which could informative or non-informative.\n",
     "\n",

--- a/unit8/Unit8-missing.ipynb
+++ b/unit8/Unit8-missing.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "3. Missing not at random (MNAR)\n",
     "\n",
-    "        Neither MCAR nor MAR hold, missingness may depend on the data that is missing, say the magnitute\n",
+    "        Neither MCAR nor MAR hold, missingness may depend on the data that is missing, say the magnitude\n",
     "\n",
     "MCAR and MAR are considered *ignorable* missingness, while MNAR is considered *non-ignorable*.\n",
     "\n",


### PR DESCRIPTION
## Fixed typos for files:
* Unit7-priors.ipynb
* Unit7-factorial.ipynb
* Unit7-multilevel.ipynb

## Fixed link for uncountable mixtures:
* Unit7-hiddenmixtures.ipynb
